### PR TITLE
Support older versions of Bootstrap.

### DIFF
--- a/sequence.json
+++ b/sequence.json
@@ -52,6 +52,18 @@
     "popover",
     "scrollspy",
     "tab",
-    "affix"
+    "affix",
+    "bootstrap-transition",
+    "bootstrap-alert",
+    "bootstrap-button",
+    "bootstrap-carousel",
+    "bootstrap-collapse",
+    "bootstrap-dropdown",
+    "bootstrap-modal",
+    "bootstrap-tooltip",
+    "bootstrap-popover",
+    "bootstrap-scrollspy",
+    "bootstrap-tab",
+    "bootstrap-affix"
   ]
 }


### PR DESCRIPTION
Thank you for the module! 

I need (ergh) to use Bootstrap 2.x. In those versions the js files are prepended with "bootstrap-*.js". So rather than rewrite your library I've just added the variations to the sequence.json which resolves my issue.